### PR TITLE
(build): optional fontawesome dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WordPress project for the [Portaal Digitale Diensten](https://openwebconcept.nl/
 3. Run `npm install` to install dependencies
 4. Run `npm start` to compile assets
 
-A FontAwesome Pro token is required to install dependencies. If you don't have one, remove the `@fortawesome/fontawesome-pro` dependency from `package.json` and then run `npm install` again.
+[You need to configure a FontAwesome Pro token](https://fontawesome.com/v6/docs/web/setup/packages#set-up-npm-token-for-all-projects), to make all fonts work as intended. However, using the intended fonts is optional and you don't need a paid license. After you have configured a token, run `npm install` again.
 
 ## ⚙️ Theme structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
 			"version": "1.0.0",
 			"license": "EUPL-1.2",
 			"dependencies": {
-				"@fortawesome/fontawesome-pro": "^6.4.2",
 				"bootstrap": "^4.6.2",
 				"js-cookie": "^3.0.5"
 			},
@@ -49,6 +48,9 @@
 				"stylelint-scss": "^5.1.0",
 				"ts-loader": "^8.4.0",
 				"typescript": "^4.9.5"
+			},
+			"optionalDependencies": {
+				"@fortawesome/fontawesome-pro": "^6.4.2"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -2404,6 +2406,7 @@
 			"version": "6.4.2",
 			"resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/6.4.2/fontawesome-pro-6.4.2.tgz",
 			"integrity": "sha512-b7VtzrgoASuCbnWJ1A17Sw3wemaFGukyBk0Y2ks/rgcnhlJ1uzdyv2uM3QbEaq9OgyZAKGJD1Tli6qHRI68zSQ==",
+			"optional": true,
 			"engines": {
 				"node": ">=6"
 			}

--- a/package.json
+++ b/package.json
@@ -76,8 +76,10 @@
 		"typescript": "^4.9.5"
 	},
 	"dependencies": {
-		"@fortawesome/fontawesome-pro": "^6.4.2",
 		"bootstrap": "^4.6.2",
 		"js-cookie": "^3.0.5"
+	},
+	"optionalDependencies": {
+		"@fortawesome/fontawesome-pro": "^6.4.2"
 	}
 }


### PR DESCRIPTION
I don't have a FontAwesome Pro token, so I'm looking for help to test if this works the way I intended. I did try adding another public package as optional dependency, and it was installed automatically — so I expect this to work.

For me the installation procedure and working in this repo is much more convenient however, because I don't need to be careful not to commit the modified `package.json` and `package-lock.json`.