### PR TITLE
(fix) add wp_body_open to header

### DIFF
--- a/htdocs/wp-content/themes/owc-formulieren/templates/header.php
+++ b/htdocs/wp-content/themes/owc-formulieren/templates/header.php
@@ -19,6 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
+    <?php wp_body_open(); ?>
     <a class="btn btn-primary btn-focus | sr-only sr-only-focusable" href="#main">Spring naar content</a>
     <div id="page">
         <div class="nav">


### PR DESCRIPTION
The DigiD logout modal wordt via de wp_body_open hook toegevoegd.