### PR TITLE
(sc30780): fix gravityforms legacy gsection styling

### DIFF
--- a/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
+++ b/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
@@ -408,9 +408,14 @@
 	}
 
 	.gsection {
+		flex-direction: column;
 		justify-content: flex-start;
-		border-bottom: 1px solid gray( '300' );
-		margin-bottom: $spacer 0;
+		margin-bottom: $spacer * 2;
+
+		.gsection_title {
+			padding-bottom: $spacer * 0.5;
+			border-bottom: 1px solid gray( '300' );
+		}
 
 		ul {
 			margin-bottom: $spacer;


### PR DESCRIPTION
De styling van het blok "sectie" ging niet goed in de legacy opmaak als er een beschrijving is toegevoegd.

Dit was het:
![image](https://github.com/user-attachments/assets/3ef9d011-d3f6-4e48-afeb-1b4293ba42a7)

Dit is het nu:
![image](https://github.com/user-attachments/assets/d498b15f-8281-4ab6-859d-b95b15d356c4)
