### PR TITLE
(sc32045): fix alignment gfrom description legacy

### DIFF
--- a/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
+++ b/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
@@ -42,9 +42,16 @@
 		margin-bottom: $spacer * 2;
 
 		@include media-breakpoint-up( md ) {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: flex-end;
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			row-gap: 0.5rem;
+		}
+
+		.gfield_description,
+		.ginput_container {
+			@include media-breakpoint-up( md ) {
+				grid-column-start: 2;
+			}
 		}
 
 		&_visibility_ {
@@ -113,8 +120,7 @@
 		font-size: $spacer;
 
 		@include media-breakpoint-up( md ) {
-			width: 51%;
-			padding-left: $spacer * 0.7;
+			padding: 0;
 		}
 
 		ul {
@@ -419,6 +425,10 @@
 		.gsection_title {
 			padding-bottom: $spacer * 0.5;
 			border-bottom: 1px solid gray( '300' );
+
+			@include media-breakpoint-up( md ) {
+				grid-column: span 2;
+			}
 		}
 
 		ul {


### PR DESCRIPTION
Als de legacy mode wordt gebruikt en de beschrijvingen worden boven de invoervelden getoond dan ging het fout.
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/946f740a-d405-4878-8755-c7055855db36" />


Opgelost:
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/c841f215-dc6e-4842-96cc-06d42f6a4446" />
