### PR TITLE
(fix): make age & municipality check fields adhere to hidden label se…

### DIFF
--- a/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
+++ b/htdocs/wp-content/themes/owc-formulieren/assets/scss/components/_gravityforms-legacy.scss
@@ -648,13 +648,6 @@
 		}
 	}
 
-	// Age & Municipality Checker styles
-	.gfield--type-owc_pg_age_check, .gfield--type-owc_pg_municipality_check {
-		&.hidden_label {
-			display: none !important;
-		}
-	}
-
 	// Honey pot
 	.gform_validation_container,
 	li.gform_validation_container,
@@ -663,5 +656,17 @@
 		position: absolute !important;
 		left: -9000px;
 		display: none !important;
+	}
+}
+
+// Specific child theme styling
+.wp-child-theme-hoekschewaard {
+	.gform_legacy_markup_wrapper.gform_wrapper {
+		// Age & Municipality Checker styles
+		.gfield--type-owc_pg_age_check, .gfield--type-owc_pg_municipality_check {
+			&.hidden_label {
+				display: none !important;
+			}
+		}
 	}
 }


### PR DESCRIPTION
Op basis van een ticket die door een gemeente is aangemaakt: "Volgens het cms zou dit veld op verborgen moeten staan, echter ziet de inwoner het veld alsnog en dit moet niet."

Sinds deze velden in principe visueel slechts uit een label bestaan, en er verder geen andere instelling is, lijkt `display: none` o.b.v de label weergave het beste.

![image](https://github.com/user-attachments/assets/7143d3be-d382-4d27-a66a-7b1783a67680)

![image](https://github.com/user-attachments/assets/bceab9a1-22a1-4465-b4cf-3ceff189b814)

